### PR TITLE
fix: Always resolve promises, even if SDK is nil

### DIFF
--- a/src/snippets/react/oneSignalFunctionTemplates.ts
+++ b/src/snippets/react/oneSignalFunctionTemplates.ts
@@ -6,6 +6,11 @@ export const reactOneSignalAsyncFunctionTemplate = (sig: IFunctionSignature) => 
   return `
   function ${sig.name}(${spreadArgsWithTypes(sig)}): ${sig.returnType || 'void'} {
     return new Promise((resolve, reject) => {
+      if (isOneSignalScriptFailed) {
+        resolve();
+        return;
+      }
+
       if (!doesOneSignalExist()) {
         reactOneSignalFunctionQueue.push({
           name: '${sig.name}',


### PR DESCRIPTION
Switch from a timeout strategy to script#onload and script#onerror so
that calls to #init will always resolve. This is important for consumers
of the react-onesignal package who want to call multiple functions
synchronously, for example:

```js
const doThingsInOrder = async () => {
  await OneSignal.init({ ... });
  await OneSignal.showSlidedownPrompt();
};
```

Without this change, those calls will hang indefinitely if adblock
prevents executing the web SDK from the cdn.onesignal.com domain.

An additional flag, `isOneSignalScriptFailed` is kept around to resolve
OneSignal SDK methods in the event of a CDN load failure. Since
resolutions in the queue are only called on `#init`, if SDK methods are
called after `#init` has already failed they will never resolve.

Here's an example issue that resulted from this bug: https://github.com/OneSignal/OneSignal/pull/8203