### PR TITLE
Remove erroneous `isPushNotificationsSupported` function

### DIFF
--- a/src/scaffolds/angular-workspace/projects/onesignal-ngx/src/lib/onesignal-ngx.service.ts
+++ b/src/scaffolds/angular-workspace/projects/onesignal-ngx/src/lib/onesignal-ngx.service.ts
@@ -167,20 +167,6 @@ export class OneSignal implements IOneSignal {
     });
   }
 
-  isPushNotificationsSupported(callback?: Action<boolean>): void {
-    if (!this.doesOneSignalExist()) {
-      this.ngOneSignalFunctionQueue.push({
-        name: 'isPushNotificationsSupported',
-        args: arguments,
-      });
-      return;
-    }
-
-    window.OneSignal.push(() => {
-      window.OneSignal.isPushNotificationsSupported(callback);
-    });
-  }
-
   isPushNotificationsEnabled(callback?: Action<boolean>): Promise<boolean> {
     return new Promise((resolve, reject) => {
       if (!this.doesOneSignalExist()) {
@@ -542,7 +528,7 @@ export class OneSignal implements IOneSignal {
     });
   }
 
-  getNotificationPermission(onComplete?: Function): Promise<NotificationPermission> {
+  getNotificationPermission(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
     return new Promise((resolve, reject) => {
       if (!this.doesOneSignalExist()) {
         this.ngOneSignalFunctionQueue.push({


### PR DESCRIPTION
Motivation: was accidentally committed during testing. This function can't take a simple callback since it returns a boolean.