### PR TITLE
[CD] Update node version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "[Setup] Node"
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: "[Setup] Bootstrap Dependencies"
         run: scripts/bootstrap-dependencies
       - name: "[Setup] Git"


### PR DESCRIPTION
## One Line Summary
Bumping CD node version to 18, this is required to build now since dependencies have changed.