### PR TITLE
Fix/cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           tar zxvvf dist/onesignal-ngx.tgz -C __clone/
           cd __clone/onesignal-ngx
-          while read file; do git rm "$file"; done < ../../build/onesignal-ngx.rmfiles
           git add -A
           if git commit -m "Update onesignal-ngx"; then
             echo "onesignal-ngx repository has been updated"
@@ -80,7 +79,6 @@ jobs:
         run: |
           tar zxvvf dist/react.tgz -C __clone/
           cd __clone/react
-          while read file; do git rm "$file"; done < ../../build/react.rmfiles
           git add -A
           if git commit -m "Update react-onesignal"; then
             echo "react-onesignal repository has been updated"
@@ -119,7 +117,6 @@ jobs:
         run: |
           tar zxvvf dist/vue/v2.tgz -C __clone/
           cd __clone/vue/v2
-          while read file; do git rm "$file"; done < ../../build/vue/v2.rmfiles
           git add -A
           if git commit -m "Update onesignal-vue"; then
             echo "onesignal-vue repository has been updated"
@@ -158,7 +155,6 @@ jobs:
         run: |
           tar zxvvf dist/vue/v3.tgz -C __clone/
           cd __clone/vue/v3
-          while read file; do git rm "$file"; done < ../../build/vue/v3.rmfiles
           git add -A
           if git commit -m "Update onesignal-vue3"; then
             echo "onesignal-vue3 repository has been updated"

--- a/scripts/build
+++ b/scripts/build
@@ -53,13 +53,6 @@ mv build/vue/v2.tgz dist/vue/v2.tgz
 mv build/vue/v3.tgz dist/vue/v3.tgz
 echo 'Done.'
 
-echo 'Diff between current build and the content of the downstream repo.'
-git diff --diff-filter=RD --name-status --no-index outputs/onesignal-ngx build/onesignal-ngx | cut -f 2 | perl -pe 's{outputs/[^/]+/}{}' >> build/onesignal-ngx.rmfiles  || true
-git diff --diff-filter=RD --name-status --no-index outputs/react build/react | cut -f 2 | perl -pe 's{outputs/[^/]+/}{}' >> build/react.rmfiles || true
-git diff --diff-filter=RD --name-status --no-index outputs/vue/v2 build/vue/v2 | cut -f 2 | perl -pe 's{outputs/[^/]+/}{}' >> build/vue/v2.rmfiles  || true
-git diff --diff-filter=RD --name-status --no-index outputs/vue/v3 build/vue/v3 | cut -f 2 | perl -pe 's{outputs/[^/]+/}{}' >> build/vue/v3.rmfiles  || true
-echo 'Done.'
-
 # This is required to use 'npm link' when testing local builds
 # We do this last so unneed files are not included in the releases.
 echo 'yarn init for local dev testing'


### PR DESCRIPTION
## One line summary
Enhanced Git staging and updated GitHub push action to the latest stable version.

## Description
This PR introduces two significant changes aimed at streamlining our development workflow and reducing potential issues caused by upstream regressions.

Firstly, we've improved the Git staging options in our documentation. Previously, we only utilized `git add .`, which limited us to staging new and modified files in the current directory and below. Now, we have incorporated `git add -A` into our process, enabling the CD process to stage all changes including modifications, deletions, and new files. 

Secondly, we have updated the GitHub push action to its latest known stable version (v0.6.0). This step is taken as a proactive measure to prevent potential issues arising from upstream regressions. By locking into a stable version, we aim to add an extra layer of reliability to our CI/CD pipeline.

These changes collectively aim to enhance code manageability and pipeline reliability, setting a more robust foundation for future development.
