### PR TITLE
Add `serviceWorkerOverrideForTypical` to IInitObject interface

### DIFF
--- a/src/snippets/InitObject.ts
+++ b/src/snippets/InitObject.ts
@@ -11,10 +11,11 @@ interface IInitObject {
   autoRegister?: boolean;
   notificationClickHandlerMatch?: string;
   notificationClickHandlerAction?: string;
+  path?: string;
   serviceWorkerParam?: { scope: string };
   serviceWorkerPath?: string;
+  serviceWorkerOverrideForTypical?: boolean;
   serviceWorkerUpdaterPath?: string;
-  path?: string;
   allowLocalhostAsSecureOrigin?: boolean;
   [key: string]: any;
 }


### PR DESCRIPTION
Motivation: update interface after most recent native SDK change allowing the override of the service worker changes even in a typical setup.

