### PR TITLE
chore(static): add release github action workflow

### DIFF
--- a/src/static/.github/workflows/release.yml
+++ b/src/static/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_WEB_SHIM_PUSH_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_WEB_SHIM_PUSH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_WEB_SHIM_PUSH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_WEB_SHIM_PUSH_TOKEN }}
+        run: |
+          npx -p semantic-release \
+              -p @semantic-release/changelog \
+              -p @semantic-release/git \
+              -p @semantic-release/github \
+              -p @semantic-release/npm \
+              -p conventional-changelog-conventionalcommits \
+              semantic-release


### PR DESCRIPTION
Adds the release workflow file found under `.github/workflows` in the downstream repos.