### PR TITLE
chore(dist): only include necessary files in the distributed tar

### DIFF
--- a/outputs/onesignal-ngx/.npmignore
+++ b/outputs/onesignal-ngx/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/outputs/onesignal-ngx/package.json
+++ b/outputs/onesignal-ngx/package.json
@@ -31,5 +31,15 @@
     "push notification",
     "angular"
   ],
+  "files": [
+    "bundles/",
+    "lib/",
+    "fesm2015/",
+    "*.d.ts",
+    "*.metadata.json",
+    "LICENSE",
+    "README.md",
+    "MigrationGuide.md"
+  ],
   "metadata": "onesignal-ngx.metadata.json"
 }

--- a/outputs/react/.npmignore
+++ b/outputs/react/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/outputs/react/index.test.ts
+++ b/outputs/react/index.test.ts
@@ -1,7 +1,7 @@
 import OneSignal from './index';
 
-const originalDocument = global.document;
-const documentSpy = vi.spyOn(global, 'document', 'get');
+const originalDocument = window.document;
+const documentSpy = vi.spyOn(window, 'document', 'get');
 
 const APP_ID = '123456';
 

--- a/outputs/react/package.json
+++ b/outputs/react/package.json
@@ -46,6 +46,13 @@
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.0.9"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",

--- a/outputs/vue/v2/.npmignore
+++ b/outputs/vue/v2/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/outputs/vue/v2/package.json
+++ b/outputs/vue/v2/package.json
@@ -26,6 +26,13 @@
     "eslint": "^8.13.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",

--- a/outputs/vue/v3/.npmignore
+++ b/outputs/vue/v3/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/outputs/vue/v3/package.json
+++ b/outputs/vue/v3/package.json
@@ -30,6 +30,13 @@
     "eslint-plugin-vue": "^9.17.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "build": "./scripts/build",
+    "build:outputs": "npm run build && ./scripts/copy-build-to-outputs",
     "prepare": "husky"
   },
   "keywords": [

--- a/src/scaffolds/angular-workspace/projects/onesignal-ngx/package.json
+++ b/src/scaffolds/angular-workspace/projects/onesignal-ngx/package.json
@@ -30,5 +30,15 @@
     "notification",
     "push notification",
     "angular"
+  ],
+  "files": [
+    "bundles/",
+    "lib/",
+    "fesm2015/",
+    "*.d.ts",
+    "*.metadata.json",
+    "LICENSE",
+    "README.md",
+    "MigrationGuide.md"
   ]
 }

--- a/src/static/.npmignore
+++ b/src/static/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/src/static/react/index.test.ts
+++ b/src/static/react/index.test.ts
@@ -1,7 +1,7 @@
 import OneSignal from './index';
 
-const originalDocument = global.document;
-const documentSpy = vi.spyOn(global, 'document', 'get');
+const originalDocument = window.document;
+const documentSpy = vi.spyOn(window, 'document', 'get');
 
 const APP_ID = '123456';
 

--- a/src/static/react/package.json
+++ b/src/static/react/package.json
@@ -46,6 +46,13 @@
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.0.9"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",

--- a/src/static/vue/v2/package.json
+++ b/src/static/vue/v2/package.json
@@ -26,6 +26,13 @@
     "eslint": "^8.13.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",

--- a/src/static/vue/v3/package.json
+++ b/src/static/vue/v3/package.json
@@ -30,6 +30,13 @@
     "eslint-plugin-vue": "^9.17.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",


### PR DESCRIPTION
## Description

This PR reduces the number of files included in the distributed tarballs that users download from npmjs.com.
It also fixes a build error in the react library test file.

### Old Dist
| Pkg Name | Pkg Size | Unpacked Size | # of Files |
|--------|--------|--------|--------|
| [react](https://github.com/OneSignal/react-onesignal) | 42.8 kB | 216.2 kB | 31 |
| [vue](https://github.com/OneSignal/onesignal-vue) | 24.2 kB | 128.2 kB | 22 |
| [vue3](https://github.com/OneSignal/onesignal-vue3) | 24.2 kB | 128.5 kB | 21 |
| [ngx](https://github.com/OneSignal/onesignal-ngx) | 66.4 kB | 342.8 kB | 32 | 

### New Dist
| Pkg Name | Pkg Size | Unpacked Size | # of Files | Pkg Size Δ% | Unpacked Size Δ% | Files Δ% |
|--------|--------|--------|--------|--------|--------|--------|
| [react](https://github.com/OneSignal/react-onesignal) | 33.8 kB | 167.4 kB | 11 | -21.0% | -22.6% | -64.5% |
| [vue](https://github.com/OneSignal/onesignal-vue) | 16.3 kB | 82.8 kB | 8 | -32.6% | -35.4% | -63.6% |
| [vue3](https://github.com/OneSignal/onesignal-vue3) | 16.6 kB | 83.6 kB | 8 | -31.4% | -34.9% | -61.9% |
| [ngx](https://github.com/OneSignal/onesignal-ngx) | 44.6 kB | 244.7 kB | 16 | -32.8% | -28.6% | -50.0% |

Resolves https://github.com/OneSignal/react-onesignal/pull/174