### PR TITLE
chore: [SDK-4491] bump package versions and update project token

### DIFF
--- a/src/scaffolds/angular-workspace/projects/onesignal-ngx/package-lock.json
+++ b/src/scaffolds/angular-workspace/projects/onesignal-ngx/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onesignal-ngx",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onesignal-ngx",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"

--- a/src/scaffolds/angular-workspace/projects/onesignal-ngx/package.json
+++ b/src/scaffolds/angular-workspace/projects/onesignal-ngx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-ngx",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "This is a JavaScript module that can be used to easily include OneSignal code in a website or app that uses Angular for its front-end codebase.",
   "contributors": [
     {

--- a/src/static/.github/workflows/project.yml
+++ b/src/static/.github/workflows/project.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           # SDK Web Project
           project-url: https://github.com/orgs/OneSignal/projects/9
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}

--- a/src/static/react/package-lock.json
+++ b/src/static/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-onesignal",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-onesignal",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.28.0",

--- a/src/static/react/package.json
+++ b/src/static/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-onesignal",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "React OneSignal Module: Make it easy to integrate OneSignal with your React App!",
   "contributors": [
     {

--- a/src/static/vue/v2/package-lock.json
+++ b/src/static/vue/v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onesignal-vue",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onesignal-vue",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "vue": "^2.6.14"

--- a/src/static/vue/v2/package.json
+++ b/src/static/vue/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-vue",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Vue OneSignal Plugin: Make it easy to integrate OneSignal with your Vue App!",
   "type": "module",
   "contributors": [

--- a/src/static/vue/v3/package-lock.json
+++ b/src/static/vue/v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onesignal/onesignal-vue3",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onesignal/onesignal-vue3",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.2.0"

--- a/src/static/vue/v3/package.json
+++ b/src/static/vue/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onesignal/onesignal-vue3",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Vue 3 OneSignal Plugin: Make it easy to integrate OneSignal with your Vue App!",
   "type": "module",
   "contributors": [


### PR DESCRIPTION
## Description

Bump shim package versions for `onesignal-ngx`, `react-onesignal`, `onesignal-vue` (v2), and `@onesignal/onesignal-vue3`, and switch the project automation workflow template from `GH_PROJECTS_TOKEN` to `GH_PUSH_TOKEN`.

## Details

- `src/scaffolds/angular-workspace/projects/onesignal-ngx`: `2.4.0` -> `2.4.1`
- `src/static/react`: `react-onesignal` `3.5.0` -> `3.5.1`
- `src/static/vue/v2`: `onesignal-vue` `2.6.0` -> `2.7.0`
- `src/static/vue/v3`: `@onesignal/onesignal-vue3` `2.4.0` -> `2.5.0`
- `src/static/.github/workflows/project.yml`: swap `GH_PROJECTS_TOKEN` for `GH_PUSH_TOKEN` (SDK Web Project board, project 9). `GH_PROJECTS_TOKEN` is being retired in favor of the `GH_PUSH_TOKEN` org secret used across all SDK repos.

### Notes
- `outputs/` was not regenerated in this PR. The version bumps and project.yml change will land in the downstream package repos on the next `scripts/build.sh` + `scripts/copy-build-to-outputs.sh` run.

Made with [Cursor](https://cursor.com)