### PR TITLE
fix: use vp exec instead of vpx in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# The build depends on the Vite+ CLI (`vp`) and Bun. `vp exec` runs project-local
+# binaries from node_modules/.bin, so it works whether `vp` was installed via the
+# official installer or as the `vite-plus` npm package (the latter does not ship
+# the global `vpx` shim). Fail fast with an actionable message if either is missing.
+for tool in vp bun; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "❌ '$tool' not found on PATH. Install Vite+ (https://vite.plus) and run 'vp install' before building." >&2
+    exit 1
+  }
+done
+
 bold=$(tput bold)
 normal=$(tput sgr0)
 
@@ -23,7 +34,7 @@ log "🧵 Transpiling"
 vp pack main.ts -d ts-to-es6 -f cjs
 
 log "⚡️ Code generation"
-vpx yellicode
+vp exec yellicode
 
 log '🧶 Bundling Angular SDK'
 (cd src/scaffolds/angular-workspace &&
@@ -51,7 +62,7 @@ mv build/vue/v3.tgz dist/vue/v3.tgz
 # We do this last so unneeded files are not included in the releases.
 log '👀 Install + Linting + Build'
 
-if vpx concurrently --kill-others-on-fail \
+if vp exec concurrently --kill-others-on-fail \
   "cd build/vue/v3 && vp install" \
   "cd build/vue/v2 && vp install" \
   "cd build/react && vp install" \


### PR DESCRIPTION
## Description

Replace `vpx` with `vp exec` in `scripts/build.sh` so the build works for maintainers who installed `vp` via the `vite-plus` npm package.

## Details

Running `bun run build:outputs` failed with `build.sh: line 26: vpx: command not found`.

**Root cause:** `vpx` is a global `npx`-style runner that ships only with the **official Vite+ installer** (and the `voidzero-dev/setup-vp` CI action). The `vite-plus` **npm package** only exposes `vp` (plus `oxlint`/`oxfmt`) — no `vpx`. Maintainers whose `vp` came from npm don't have `vpx`, so the build broke locally even though CI (which uses `setup-vp`) was fine.

**Fix:**
- `vpx yellicode` → `vp exec yellicode`
- `vpx concurrently` → `vp exec concurrently`

`vp exec` runs binaries from the project's `node_modules/.bin` and is provided by the `vite-plus` package itself, so it works regardless of how `vp` was installed. Both binaries (`@yellicode/cli`, `concurrently`) are already project dependencies, and using the pinned local version is safer than `vpx`'s download-on-demand behavior.

Also adds a **preflight guard** at the top of `build.sh` that fails fast with an actionable message (pointing to https://vite.plus) if `vp` or `bun` is missing from PATH, so future toolchain gaps surface clearly instead of as a cryptic mid-build `command not found`.

## Testing

- `bash -n scripts/build.sh` passes; `shellcheck` reports no issues.
- `vp exec yellicode` runs the code-generation step successfully ("Code generation done").
- `vp exec concurrently --version` resolves (9.2.1).

## Notes

The same `vpx` pattern also appears in the `src/static/**` release workflows and the ngx example `start.sh`; those run in CI where `setup-vp` provides `vpx`, so they're lower risk and intentionally left out of this PR's scope.